### PR TITLE
Do not override the cache stats with stats from the '_bind' view

### DIFF
--- a/bind-stats.py
+++ b/bind-stats.py
@@ -138,7 +138,8 @@ else:
             # V2: no (only in memory detail stats)
             if child.attrib['type'] == 'cachestats':
                 for stat in child.iterfind('./counter'):
-                    j['cache'][stat.attrib['name']] = stat.text
+                    if not stat.attrib['name'] in j['cache'].keys():
+                        j['cache'][stat.attrib['name']] = stat.text
         # V2 has @name = localhost_resolver, interal, external
         for child in root.iterfind('./views/view/cache'):
             if (child.attrib['name'] == '_default'):


### PR DESCRIPTION
I'll admit, I don't understand what the '_bind' view is for, but it clearly doesn't contain accurate cache stats based on my generic BIND config (0 cache hits, 0 cache misses, 0 db nodes).

From my named.stats file:
```
++ Cache Statistics ++
[View: default]
              110643 cache hits
                  91 cache misses
               21609 cache hits (from query)
                4939 cache misses (from query)
                   0 cache records deleted due to memory exhaustion
                3204 cache records deleted due to TTL expiration
                2505 cache database nodes
                1039 cache database hash buckets
             1074664 cache tree memory total
              610980 cache tree memory in use
              637268 cache tree highest memory in use
              327680 cache heap memory total
               66112 cache heap memory in use
               66112 cache heap highest memory in use
[View: _bind (Cache: _bind)]
                   0 cache hits
                   0 cache misses
                   0 cache hits (from query)
                   0 cache misses (from query)
                   0 cache records deleted due to memory exhaustion
                   0 cache records deleted due to TTL expiration
                   0 cache database nodes
                  64 cache database hash buckets
              282000 cache tree memory total
               22728 cache tree memory in use
               22728 cache tree highest memory in use
              262144 cache heap memory total
                 576 cache heap memory in use
                 576 cache heap highest memory in use

```
Each view contains the same statistics, so simply avoid recording a given stat if we've already seen it from the earlier 'default' view.
